### PR TITLE
Fixed appbar red to gray

### DIFF
--- a/src/components/layout.module.scss
+++ b/src/components/layout.module.scss
@@ -41,7 +41,7 @@
     }
 }
 
-.header {
+:global(.MuiAppBar-root).header {
     background-color: #f1f2f2;
     width: 100%;
     & .MuiToolbar-root {


### PR DESCRIPTION
I styled the AppBar with a CSS selector that had the same specificity as some other MUI selector. The problem was that Next.js ordered the generated source code differently in development and in production. So my CSS was not used in production (was overriden by the MUI defaults), but seemd to work fine in development (it had precedence here).

It should now always look like this:
![image](https://github.com/ufal/charles-translator-web-frontend/assets/9805164/3ea08474-a76e-4709-8e26-670341adad91)
